### PR TITLE
update XML file names, since `ecce` is starting to use Jinja

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,10 +194,11 @@ source environ.sh
       - materials etc. are referenced by name in `compact/drich.xml`
       - most of these tables were obtained from the
         [common optics class](https://github.com/cisbani/dRICh/blob/main/share/source/g4dRIChOptics.hh)
-    - the full detector compact file is `ecce.xml`, and there is also a
-      dRICH-only compact file `compact/subsystem_views/drich_only.xml`; these
-      compact files are used by many scripts, such as `npsim` (whereas `compact/drich.xml` is
-      *only* for the dRICH implementation itself)
+    - the full detector compact file is `ecce.xml`, which is generated via
+      Jinja during `cmake` (run `buildECCE.sh`), along with a dRICH-only
+      compact file `ecce_drich_only.xml`; these compact files are used by many
+      scripts, such as `npsim` (whereas `compact/drich.xml` is *only* for the
+      dRICH implementation itself)
     - `src/DRICH_geo.cpp` is the C++ source file for the dRICH
       - relies on constants from the compact files
       - builds the dRICH

--- a/runDDwebDisplay.sh
+++ b/runDDwebDisplay.sh
@@ -4,9 +4,9 @@ set -e
 # set compact file, depending on (optional) argument; default is full ecce
 compactFile=$(
   case "$1" in
-    ("d") echo "compact/subsystem_views/drich_only.xml"  ;;
-    ("p") echo "compact/subsystem_views/pfrich_only.xml" ;;
-    (*)   echo "ecce.xml"                                ;;
+    ("d") echo "ecce_drich_only.xml"  ;;
+    ("p") echo "ecce_pfrich_only.xml" ;;
+    (*)   echo "ecce.xml"             ;;
   esac)
 echo "compactFile = $compactFile"
 

--- a/simulate.py
+++ b/simulate.py
@@ -137,7 +137,7 @@ localDir = os.environ['LOCAL_DATA_PATH']
 
 ### set compact file
 compactFileFull = detPath+'/'+detMain+'.xml'
-compactFileRICH = detPath+'/compact/subsystem_views/'+xrich+'_only.xml'
+compactFileRICH = detPath+'/'+detMain+'_'+xrich+'_only.xml'
 compactFile = compactFileRICH if standalone else compactFileFull
 
 ### print args and settings


### PR DESCRIPTION
XML files `ecce.xml` and `drich_only.xml` are now produced with `jinja`,
which happens automatically during `cmake` (`buildECCE.sh`). Scripts
that depend on these files have been updated to point to their new
locations.

See https://eicweb.phy.anl.gov/EIC/detectors/ecce/-/merge_requests/27