### PR TITLE
document running `jsroot` locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ ecce
 ip6
 eicd
 reconstruction_benchmarks
+jsroot
 
 calibrations
 fieldmaps

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ source environ.sh
 - open the resulting ROOT file in `jsroot` geoviewer, using either:
   - [ANL hosted instance](https://eic.phy.anl.gov/geoviewer/)
   - [CERN hosted instance](https://root.cern/js/)
-  - a locally hosted instance
+  - a locally hosted instance (see below)
 - browse the ROOT file geometry tree in the sidebar on the left:
   ```
   detector_geometry.root
@@ -248,6 +248,20 @@ source environ.sh
   - the search pattern is case sensitive
   - this script is just a wrapper for `npdet_info`, run `npdet_info -h` for
     further guidance
+
+### Locally Hosting JSroot
+
+It is convenient to locally run JSroot, so you can automate opening and
+viewing the geometry. First, clone the JSroot repository:
+```
+git clone https://github.com/root-project/jsroot.git
+```
+Then run `./startJSroot.sh`, which will start a local HTTP server. To open JSroot, navigate to <http://localhost:8000>. For convenience, to automatically open `geo/detector_geometry.root`, produced by `runDDwebDisplay.sh`, open:
+
+<http://localhost:8000/?dark&file=geo/detector_geometry.root>
+
+Remove `?dark` from the URL if you prefer light mode; it is recommended to bookmark this link.
+
 
 ### GDML Output
 - currently we use the CI for this, from the `ecce` repository

--- a/README.md
+++ b/README.md
@@ -218,9 +218,9 @@ source environ.sh
   - run `./runDDwebDisplay.sh p` to run on pfRICH only
   - output ROOT file will be in `geo/`
 - open the resulting ROOT file in `jsroot` geoviewer, using either:
-  - [ANL hosted instance](https://eic.phy.anl.gov/geoviewer/)
-  - [CERN hosted instance](https://root.cern/js/)
-  - a locally hosted instance (see below)
+  - [CERN host](https://root.cern/js/) (recommended)
+  - Local host (advanced, but offers better control; see below)
+  - [ANL hosted](https://eic.phy.anl.gov/geoviewer/)
 - browse the ROOT file geometry tree in the sidebar on the left:
   ```
   detector_geometry.root
@@ -251,16 +251,33 @@ source environ.sh
 
 ### Locally Hosting JSroot
 
-It is convenient to locally run JSroot, so you can automate opening and
-viewing the geometry. First, clone the JSroot repository:
+It is convenient to locally run JSroot, so you can automate opening and viewing
+the geometry. Follow the [JSroot documentation](https://github.com/root-project/jsroot/blob/master/docs/JSROOT.md)
+to learn how to set custom settings with URLs, and much more.
+
+First either obtain a release or clone the JSroot repository; you can
+clone it to any directory (does not have to be in `drich-dev/`)
 ```
 git clone https://github.com/root-project/jsroot.git
 ```
-Then run `./startJSroot.sh`, which will start a local HTTP server. To open JSroot, navigate to <http://localhost:8000>. For convenience, to automatically open `geo/detector_geometry.root`, produced by `runDDwebDisplay.sh`, open:
+Then `cd` to this `jsroot` directory. Make a symlink to the `drich-dev/geo`
+directory, so that your local HTTP server can access ROOT files within:
+```
+ln -sv /path/to/drich-dev/geo ./
+```
+Now start an HTTP server. For example, using python:
+```
+python -m http.server
+```
+Note which port is used, likely `8000`. Now open your browser and open the URL
+<http://localhost:8000> to start JSroot in the browser (change the port number
+if yours is different) 
+
+Various settings can be set via the URL. For example, the following URL
+automatically opens the `detector_geometry.root` file (produced by
+`runDDwebDisplay.sh`) using `file=...`, and enables dark mode:
 
 <http://localhost:8000/?file=geo/detector_geometry.root&dark>
-
-Remove `&dark` from the URL if you prefer light mode; it is recommended to bookmark this link.
 
 
 ### GDML Output

--- a/README.md
+++ b/README.md
@@ -258,9 +258,9 @@ git clone https://github.com/root-project/jsroot.git
 ```
 Then run `./startJSroot.sh`, which will start a local HTTP server. To open JSroot, navigate to <http://localhost:8000>. For convenience, to automatically open `geo/detector_geometry.root`, produced by `runDDwebDisplay.sh`, open:
 
-<http://localhost:8000/?dark&file=geo/detector_geometry.root>
+<http://localhost:8000/?file=geo/detector_geometry.root&dark>
 
-Remove `?dark` from the URL if you prefer light mode; it is recommended to bookmark this link.
+Remove `&dark` from the URL if you prefer light mode; it is recommended to bookmark this link.
 
 
 ### GDML Output

--- a/startJSroot.sh
+++ b/startJSroot.sh
@@ -6,3 +6,4 @@ ln -svf ../geo jsroot/
 # start a local server
 pushd jsroot
 python -m http.server
+popd

--- a/startJSroot.sh
+++ b/startJSroot.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-# link `geo` directory, so local HTTP server can access it
-ln -svf ../geo jsroot/
-
-# start a local server
-pushd jsroot
-python -m http.server
-popd

--- a/startJSroot.sh
+++ b/startJSroot.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# link `geo` directory, so local HTTP server can access it
+ln -svf ../geo jsroot/
+
+# start a local server
+pushd jsroot
+python -m http.server


### PR DESCRIPTION
to reduce the number of mouse clicks to view the dRICH geometry